### PR TITLE
CI failure for testGroupPermission

### DIFF
--- a/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
+++ b/zeppelin-server/src/test/java/org/apache/zeppelin/integration/AuthenticationIT.java
@@ -124,7 +124,7 @@ public class AuthenticationIT extends AbstractZeppelinIT {
         userName + "')]")).click();
     ZeppelinITUtils.sleep(500, false);
     driver.findElement(By.xpath("//div[contains(@class, 'navbar-collapse')]//li[contains(.,'" +
-        userName + "')]//a[@ng-click='logout()']")).click();
+        userName + "')]//a[@ng-click='navbar.logout()']")).click();
     ZeppelinITUtils.sleep(5000, false);
   }
 


### PR DESCRIPTION
Selenium was failing as it was not able to get "logout()", since the name is now changed to "navbar.logout()"
